### PR TITLE
changed dependencies from sight to camposs and now uses boost 1.64

### DIFF
--- a/conanfile.py
+++ b/conanfile.py
@@ -39,16 +39,17 @@ class LibPCLConan(ConanFile):
 
     def configure(self):
         del self.settings.compiler.libcxx
+        self.options["Boost"].shared=True
         if 'CI' not in os.environ:
             os.environ["CONAN_SYSREQUIRES_MODE"] = "verify"
 
     def requirements(self):
         self.requires("qt/5.12.2@sight/stable")
-        self.requires("eigen/3.3.7@sight/stable")
-        self.requires("boost/1.69.0@sight/stable")
-        self.requires("vtk/8.2.0@sight/stable")
-        self.requires("openni/2.2.0-r2@sight/stable")
-        self.requires("flann/1.9.1-r1@sight/stable")
+        self.requires("eigen/3.3.7@camposs/stable")
+        self.requires("Boost/1.64.0@camposs/stable")
+        self.requires("vtk/8.2.0-r1@camposs/stable")
+        self.requires("openni/2.2.0-r3@camposs/stable")
+        self.requires("flann/1.9.1-r2@camposs/stable")
 
         if tools.os_info.is_windows:
             self.requires("zlib/1.2.11-r1@sight/stable")
@@ -165,3 +166,4 @@ class LibPCLConan(ConanFile):
 
     def package_info(self):
         self.cpp_info.libs = tools.collect_libs(self)
+        self.cpp_info.includedirs = ['include/pcl-1.9'];


### PR DESCRIPTION
moved sight dependencies to camposs dependencies, changed include path form `<pcl-1.9/pcl/...>` to `<pcl/...>`