### PR TITLE
Fixing frustum culling build error

### DIFF
--- a/conanfile.py
+++ b/conanfile.py
@@ -31,6 +31,7 @@ class LibPCLConan(ConanFile):
         "patches/point_cloud.diff",
         "patches/pcl_supervoxel_clustering.diff",
         "patches/cmake_add_new_boost_versions.diff",
+        "patches/frustum_culling.diff",
     ]
     url = "https://git.ircad.fr/conan/conan-pcl"
     license = "BSD License"
@@ -60,7 +61,7 @@ class LibPCLConan(ConanFile):
         self.requires("ircad_common/1.0.2@camposs/stable")
         self.requires("qt/5.12.4-r2@camposs/stable")
         self.requires("eigen/3.3.7@camposs/stable")
-        self.requires("Boost/1.70.0@camposs/stable")
+        self.requires("Boost/1.72.0@camposs/stable")
         self.requires("vtk/8.2.0-r4@camposs/stable")
         self.requires("openni/2.2.0-r3@camposs/stable")
         self.requires("flann/1.9.1-r5@camposs/stable")
@@ -105,6 +106,7 @@ class LibPCLConan(ConanFile):
         tools.patch(pcl_source_dir, "patches/point_cloud.diff")
         tools.patch(pcl_source_dir, "patches/pcl_supervoxel_clustering.diff")
         tools.patch(pcl_source_dir, "patches/cmake_add_new_boost_versions.diff")
+        tools.patch(pcl_source_dir, "patches/frustum_culling.diff")
 
         # patch for cuda arch >7.0
 

--- a/patches/frustum_culling.diff
+++ b/patches/frustum_culling.diff
@@ -1,0 +1,94 @@
+diff --git a/filters/include/pcl/filters/impl/frustum_culling.hpp b/filters/include/pcl/filters/impl/frustum_culling.hpp
+index 81fe09f255..2e50ae1ba7 100644
+--- a/filters/include/pcl/filters/impl/frustum_culling.hpp
++++ b/filters/include/pcl/filters/impl/frustum_culling.hpp
+@@ -82,43 +82,43 @@ pcl::FrustumCulling<PointT>::applyFilter (std::vector<int> &indices)
+   Eigen::Vector4f pl_r; // right plane
+   Eigen::Vector4f pl_l; // left plane
+ 
+-  Eigen::Vector3f view = camera_pose_.block (0, 0, 3, 1);    // view vector for the camera  - first column of the rotation matrix
+-  Eigen::Vector3f up = camera_pose_.block (0, 1, 3, 1);      // up vector for the camera    - second column of the rotation matrix
+-  Eigen::Vector3f right = camera_pose_.block (0, 2, 3, 1);   // right vector for the camera - third column of the rotation matrix
+-  Eigen::Vector3f T = camera_pose_.block (0, 3, 3, 1);       // The (X, Y, Z) position of the camera w.r.t origin
++  Eigen::Vector3f view = camera_pose_.block<3, 1> (0, 0);    // view vector for the camera  - first column of the rotation matrix
++  Eigen::Vector3f up = camera_pose_.block<3, 1> (0, 1);      // up vector for the camera    - second column of the rotation matrix
++  Eigen::Vector3f right = camera_pose_.block<3, 1> (0, 2);   // right vector for the camera - third column of the rotation matrix
++  Eigen::Vector3f T = camera_pose_.block<3, 1> (0, 3);       // The (X, Y, Z) position of the camera w.r.t origin
+ 
+ 
+-  float vfov_rad = float (vfov_ * M_PI / 180); // degrees to radians
+-  float hfov_rad = float (hfov_ * M_PI / 180); // degrees to radians
++  float vfov_rad = float (vfov_ * M_PI / 180);  // degrees to radians
++  float hfov_rad = float (hfov_ * M_PI / 180);  // degrees to radians
+   
+   float np_h = float (2 * tan (vfov_rad / 2) * np_dist_);  // near plane height
+   float np_w = float (2 * tan (hfov_rad / 2) * np_dist_);  // near plane width
+ 
+-  float fp_h = float (2 * tan (vfov_rad / 2) * fp_dist_);    // far plane height
+-  float fp_w = float (2 * tan (hfov_rad / 2) * fp_dist_);    // far plane width
++  float fp_h = float (2 * tan (vfov_rad / 2) * fp_dist_);  // far plane height
++  float fp_w = float (2 * tan (hfov_rad / 2) * fp_dist_);  // far plane width
+ 
+-  Eigen::Vector3f fp_c (T + view * fp_dist_);                 // far plane center
++  Eigen::Vector3f fp_c (T + view * fp_dist_);                           // far plane center
+   Eigen::Vector3f fp_tl (fp_c + (up * fp_h / 2) - (right * fp_w / 2));  // Top left corner of the far plane
+   Eigen::Vector3f fp_tr (fp_c + (up * fp_h / 2) + (right * fp_w / 2));  // Top right corner of the far plane
+   Eigen::Vector3f fp_bl (fp_c - (up * fp_h / 2) - (right * fp_w / 2));  // Bottom left corner of the far plane
+   Eigen::Vector3f fp_br (fp_c - (up * fp_h / 2) + (right * fp_w / 2));  // Bottom right corner of the far plane
+ 
+-  Eigen::Vector3f np_c (T + view * np_dist_);                   // near plane center
+-  //Eigen::Vector3f np_tl = np_c + (up * np_h/2) - (right * np_w/2); // Top left corner of the near plane
+-  Eigen::Vector3f np_tr (np_c + (up * np_h / 2) + (right * np_w / 2));   // Top right corner of the near plane
+-  Eigen::Vector3f np_bl (np_c - (up * np_h / 2) - (right * np_w / 2));   // Bottom left corner of the near plane
+-  Eigen::Vector3f np_br (np_c - (up * np_h / 2) + (right * np_w / 2));   // Bottom right corner of the near plane
++  Eigen::Vector3f np_c (T + view * np_dist_);                           // near plane center
++  //Eigen::Vector3f np_tl = np_c + (up * np_h/2) - (right * np_w/2);    // Top left corner of the near plane
++  Eigen::Vector3f np_tr (np_c + (up * np_h / 2) + (right * np_w / 2));  // Top right corner of the near plane
++  Eigen::Vector3f np_bl (np_c - (up * np_h / 2) - (right * np_w / 2));  // Bottom left corner of the near plane
++  Eigen::Vector3f np_br (np_c - (up * np_h / 2) + (right * np_w / 2));  // Bottom right corner of the near plane
+ 
+-  pl_f.block (0, 0, 3, 1).matrix () = (fp_bl - fp_br).cross (fp_tr - fp_br);   // Far plane equation - cross product of the 
+-  pl_f (3) = -fp_c.dot (pl_f.block (0, 0, 3, 1));                    // perpendicular edges of the far plane
++  pl_f.head<3> () = (fp_bl - fp_br).cross (fp_tr - fp_br);  // Far plane equation - cross product of the 
++  pl_f (3) = -fp_c.dot (pl_f.head<3> ());                   // perpendicular edges of the far plane
+ 
+-  pl_n.block (0, 0, 3, 1).matrix () = (np_tr - np_br).cross (np_bl - np_br);   // Near plane equation - cross product of the 
+-  pl_n (3) = -np_c.dot (pl_n.block (0, 0, 3, 1));                    // perpendicular edges of the far plane
++  pl_n.head<3> () = (np_tr - np_br).cross (np_bl - np_br);  // Near plane equation - cross product of the 
++  pl_n (3) = -np_c.dot (pl_n.head<3> ());                   // perpendicular edges of the far plane
+ 
+-  Eigen::Vector3f a (fp_bl - T);    // Vector connecting the camera and far plane bottom left
+-  Eigen::Vector3f b (fp_br - T);    // Vector connecting the camera and far plane bottom right
+-  Eigen::Vector3f c (fp_tr - T);    // Vector connecting the camera and far plane top right
+-  Eigen::Vector3f d (fp_tl - T);    // Vector connecting the camera and far plane top left
++  Eigen::Vector3f a (fp_bl - T);  // Vector connecting the camera and far plane bottom left
++  Eigen::Vector3f b (fp_br - T);  // Vector connecting the camera and far plane bottom right
++  Eigen::Vector3f c (fp_tr - T);  // Vector connecting the camera and far plane top right
++  Eigen::Vector3f d (fp_tl - T);  // Vector connecting the camera and far plane top left
+ 
+   //                   Frustum and the vectors a, b, c and d. T is the position of the camera
+   //                             _________
+@@ -133,15 +133,15 @@ pcl::FrustumCulling<PointT>::applyFilter (std::vector<int> &indices)
+   //                   T
+   //
+ 
+-  pl_r.block (0, 0, 3, 1).matrix () = b.cross (c);
+-  pl_l.block (0, 0, 3, 1).matrix () = d.cross (a);
+-  pl_t.block (0, 0, 3, 1).matrix () = c.cross (d);
+-  pl_b.block (0, 0, 3, 1).matrix () = a.cross (b);
++  pl_r.head<3> () = b.cross (c);
++  pl_l.head<3> () = d.cross (a);
++  pl_t.head<3> () = c.cross (d);
++  pl_b.head<3> () = a.cross (b);
+ 
+-  pl_r (3) = -T.dot (pl_r.block (0, 0, 3, 1));
+-  pl_l (3) = -T.dot (pl_l.block (0, 0, 3, 1));
+-  pl_t (3) = -T.dot (pl_t.block (0, 0, 3, 1));
+-  pl_b (3) = -T.dot (pl_b.block (0, 0, 3, 1));
++  pl_r (3) = -T.dot (pl_r.head<3> ());
++  pl_l (3) = -T.dot (pl_l.head<3> ());
++  pl_t (3) = -T.dot (pl_t.head<3> ());
++  pl_b (3) = -T.dot (pl_b.head<3> ());
+ 
+   if (extract_removed_indices_)
+   {


### PR DESCRIPTION
With recent Eigen versions, a static_assertation can hit during the build inside frustum_culling.hpp: 
 [https://github.com/PointCloudLibrary/pcl/pull/2786](https://github.com/PointCloudLibrary/pcl/pull/2786)

This PR applies the patch for the fix that is alredy in PCL upstream, but not in version 1.9.

Also upgrading Boost to 1.72 from 1.70 to prevent more version conflicts 